### PR TITLE
refactor(metadata): Enhance EC & GO term processing with header-based parsing and flexible regex

### DIFF
--- a/mantis/database_generator.py
+++ b/mantis/database_generator.py
@@ -19,9 +19,9 @@ if not unifunc_downloaded():
 def validate_ec_numbers(ec_field):
     """
     Given a comma-separated EC field, returns only values matching
-    the pattern: <digit>.<digit>.<digit>.<digit> or dash in the fourth field.
+    the pattern: <digit>.<digit>.<digit>.<digit> or dashes.
     """
-    pattern = re.compile(r'^\d+\.\d+\.\d+\.(\d+|-)$')
+    pattern = re.compile(r'^(\d+|-)\.(\d+|-)\.(\d+|-)\.(\d+|-)$')
     valid = []
     for item in ec_field.split(','):
         item = item.strip()

--- a/mantis/database_generator.py
+++ b/mantis/database_generator.py
@@ -35,14 +35,15 @@ def validate_ec_numbers(ec_field):
 def validate_go_terms(go_field):
     """
     Given a comma-separated GO terms field, returns only terms matching
-    the pattern: GO:<digits>.
+    the pattern: GO:<digits>, but stripped of the 'GO:' prefix.
     """
     pattern = re.compile(r'^GO:\d+$')
     valid = []
     for item in go_field.split(','):
         item = item.strip()
         if item and pattern.match(item):
-            valid.append(item)
+            # Strip the "GO:" prefix so that the returned term matches old output.
+            valid.append(item.replace("GO:", ""))
         else:
             print(f"Warning: Invalid GO term format: '{item}'")
     return valid

--- a/mantis/utils.py
+++ b/mantis/utils.py
@@ -303,15 +303,19 @@ def find_tigrfam(string_to_search):
         res.add(i.group())
     return res
 
-
 def find_go(string_to_search):
+    """
+    Find GO terms in the given string.
+    
+    This function looks for patterns matching 'GO' optionally followed by a colon,
+    and then at least three digits. It returns a set of the digits only (without the 'GO' or colon),
+    so that downstream processing can safely prepend 'go:'.
+    """
     res = set()
-    pattern = re.compile('(?<![A-Za-z])GO\d{3,}')
-    search = re.finditer(pattern, string_to_search)
-    for i in search:
-        res.add(i.group())
+    pattern = re.compile(r'(?<![A-Za-z])GO:?(\d{3,})')
+    for match in re.finditer(pattern, string_to_search):
+        res.add(match.group(1))
     return res
-
 
 def get_seqs_count(target_sample):
     total_seqs = 0


### PR DESCRIPTION
This pull request consolidates four improvements to our NCBI metadata pipeline to increase robustness against changes in file format:

    Header-based Parsing:
    The metadata parser in sort_hmms_NCBI() has been refactored to dynamically read the header line from the NCBI metadata TSV (e.g. hmm_PGAP.tsv) and create a mapping from column names to indices. This change removes the reliance on fixed column positions and ensures that if the column order changes, the correct fields (e.g. ncbi_accession, label, product_name, ec_numbers, go_terms, and taxonomic_range) will be used.

    Enhanced EC Number Validation:
    The validate_ec_numbers() function has been updated to use a regex that accepts dashes in any of the four fields (not only the last one), ensuring that all valid enzyme EC numbers are correctly recognized.

    GO Term Validation and Normalization:
    The validate_go_terms() function now validates GO terms against the pattern GO:<digits> and strips the "GO:" prefix so that downstream formatting (which prepends go:) yields identifiers like go:0008800.

    Flexible GO Term Extraction:
    The find_go() function has been revised to accept GO terms whether they include a colon or not (i.e. matching both GO:0008800 and GO0008800) and returns only the numeric portion. This makes the parser resilient if the NCBI format changes again.